### PR TITLE
Add items from the DICTIONARY_AUTHOR category as recommended

### DIFF
--- a/ddl.dic
+++ b/ddl.dic
@@ -2660,7 +2660,10 @@ save_
                                    '_dictionary_audit.date'
                                    '_dictionary_audit.revision'
                                    '_dictionary.doi'
-                                   '_dictionary.licensing_spdx']
+                                   '_dictionary.licensing_spdx'
+                                   '_dictionary_author.name'
+                                   '_dictionary_author.id_orcid'
+                                   '_dictionary_author.email']
          Dictionary  Prohibited   [ALIAS  CATEGORY_KEY  DEFINITION
                                    DESCRIPTION_EXAMPLE  ENUMERATION  IMPORT
                                    METHOD  NAME  TYPE  UNITS]

--- a/ddl.dic
+++ b/ddl.dic
@@ -3253,4 +3253,7 @@ save_
        categories, added usage examples.
 
        Added a new 'Iri' content type (see _type.contents attribute).
+
+       Added '_dictionary_author.name', '_dictionary_author.id_orcid' and
+       '_dictionary_author.email' to the recommended attribute list.
 ;


### PR DESCRIPTION
Resolves issue #2.

Note, that after merging this PR all dictionaries without dictionary author attributes will start failing the automated checks. 