### PR TITLE
Add the `Iri` content type

### DIFF
--- a/ddl.dic
+++ b/ddl.dic
@@ -11,7 +11,7 @@ data_DDL_DIC
     _dictionary.title             DDL_DIC
     _dictionary.class             Reference
     _dictionary.version           4.2.0
-    _dictionary.date              2026-02-24
+    _dictionary.date              2026-02-25
     _dictionary.uri
         https://raw.githubusercontent.com/COMCIFS/DDLm/main/ddl.dic
     _dictionary.ddl_conformance   4.2.0
@@ -2134,7 +2134,7 @@ save_type.contents
 
     _definition.id                '_type.contents'
     _definition.class             Attribute
-    _definition.update            2025-07-04
+    _definition.update            2026-02-25
     _description.text
 ;
     Syntax of the value elements within the container type. Where the
@@ -2200,6 +2200,10 @@ save_type.contents
 ;
          Uniform Resource Identifier reference as defined in RFC 3986 Section
          4.1.
+;
+         Iri
+;
+         Internationalized Resource Identifier as defined in RFC 3987.
 ;
          Date
 ;
@@ -3185,7 +3189,7 @@ save_
        by explicitly specifying that it adheres to the formal grammar
        provided in SemVer version 2.0.0.
 ;
-         4.2.0                    2026-02-24
+         4.2.0                    2026-02-25
 ;
        # Please update the date above and describe the change below until
        # ready for the next release
@@ -3244,4 +3248,6 @@ save_
 
        Specified that the DEFINITION_REPLACED category may be used to deprecate
        categories, added usage examples.
+
+       Added a new 'Iri' content type (see _type.contents attribute).
 ;


### PR DESCRIPTION
Closes issue #17.

For now, I opted for a more restrictive definition allows only full IRIs and not relative IRIs. Alternatively, we could phrase it in the same way as the URI definition to allow both full and relative IRIs (identifier vs. identifier reference), however, I am unsure if this is currently needed.