### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,8 +31,8 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - name: Checkout
-        uses: actions/checkout@v4
+      - name: Check out the target repository
+        uses: actions/checkout@v6
 
       # Check syntax of all CIF files
       - name: Check CIF syntax
@@ -45,11 +45,11 @@ jobs:
     needs: syntax
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - name: Check out the target repository
+        uses: actions/checkout@v6
 
-      - name: Checkout enumeration templates
-        uses: actions/checkout@v4
+      - name: Check out enumeration templates
+        uses: actions/checkout@v6
         with:
           repository: COMCIFS/Enumeration_Templates
           path: cif-dictionaries/Enumeration_Templates
@@ -63,37 +63,41 @@ jobs:
     runs-on: ubuntu-latest
     needs: syntax
 
+    env:
+        JULIA_VERSION: '1.10'
+        JULIA_DEP_FILE: 'julia_cif_tools/Project.toml'
+
     steps:
-      - name: Get the cache
-        uses: actions/cache@v4
-        id: cache
-        with:
-          path: ~/.julia
-          key: ${{ runner.os }}-julia-v2
-
       - name: Install Julia
-        uses: julia-actions/setup-julia@v2
+        uses: julia-actions/setup-julia@v3
         with:
-          version: '1.10'
+          version: ${{ env.JULIA_VERSION }}
 
-      - name: Install Julia packages
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          julia -e 'import Pkg;Pkg.add("CrystalInfoFramework");Pkg.add("Lerche");Pkg.add("ArgParse")'
-
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          path: main
-
-      - name: Checkout julia tools
-        uses: actions/checkout@v4
+      - name: Check out Julia tools
+        uses: actions/checkout@v6
         with:
           repository: jamesrhester/julia_cif_tools
           path: julia_cif_tools
 
-      - name: Checkout enumeration templates
-        uses: actions/checkout@v4
+      - name: Get the cache
+        uses: actions/cache@v5
+        id: cache
+        with:
+          path: ~/.julia
+          key: ${{ runner.os }}-julia-${{ env.JULIA_VERSION }}-${{ hashFiles(env.JULIA_DEP_FILE) }}
+
+      - name: Install Julia packages
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          julia -e 'using Pkg, TOML; map(Pkg.add, collect(keys(TOML.parsefile("${{ env.JULIA_DEP_FILE }}")["deps"]))); Pkg.instantiate()'
+
+      - name: Check out the target repository
+        uses: actions/checkout@v6
+        with:
+          path: main
+
+      - name: Check out enumeration templates
+        uses: actions/checkout@v6
         with:
           repository: COMCIFS/Enumeration_Templates
           path: enum


### PR DESCRIPTION
The update includes switching to GitHub actions that do not depend on the now deprecated Node20, and using a more robust Julia dependency caching approach.