### PR TITLE
Explicitly deprecate the ENUMERATION_DEFAULT category

### DIFF
--- a/ddl.dic
+++ b/ddl.dic
@@ -11,7 +11,7 @@ data_DDL_DIC
     _dictionary.title             DDL_DIC
     _dictionary.class             Reference
     _dictionary.version           4.2.1-dev
-    _dictionary.date              2026-02-25
+    _dictionary.date              2026-06-08
     _dictionary.uri
         https://raw.githubusercontent.com/COMCIFS/DDLm/main/ddl.dic
     _dictionary.ddl_conformance   4.2.0
@@ -1262,7 +1262,9 @@ save_ENUMERATION_DEFAULT
     _definition.id                ENUMERATION_DEFAULT
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2023-06-23
+    _definition_replaced.id       1
+    _definition_replaced.by       .
+    _definition.update            2026-06-08
     _description.text
 ;
     Deprecated. The ENUMERATION_DEFAULTS category should be used instead
@@ -3237,7 +3239,7 @@ save_
        Added '_dictionary_author.name', '_dictionary_author.id_orcid' and
        '_dictionary_author.email' to the recommended attribute list.
 ;
-         4.2.1-dev                2026-02-25
+         4.2.1-dev                2026-06-08
 ;
        # Please add changes below and change the update date above until ready
        # for next release


### PR DESCRIPTION
All items from the the ENUMERATION_DEFAULT category were previously deprecated therefore the category itself should also be deprecated as this is now allowed by the DEFINITION_REPLACED category.

It might also make sense to integrate this change into the rc branch.