### PR TITLE
Update description for numerical value ranges

### DIFF
--- a/ddl.dic
+++ b/ddl.dic
@@ -1228,10 +1228,10 @@ save_enumeration.range
     _definition.update            2023-01-09
     _description.text
 ;
-    The inclusive range of numerical values allowed for the defined item, or
-    for all elements of 'Array' or 'List' types, or for all values of 'Table'
-    types. If the defined item has associated SU values, the reported data
-    values may fall outside these limits.
+    The inclusive range of numerical values allowed for the defined item,
+    or for all elements of 'Array', 'List' or 'Matrix' types, or for all
+    values of 'Table' types. If the defined item has associated SU values,
+    the reported data values may fall outside these limits.
 ;
     _name.category_id             enumeration
     _name.object_id               range

--- a/ddl.dic
+++ b/ddl.dic
@@ -1229,8 +1229,8 @@ save_enumeration.range
     _description.text
 ;
     The inclusive range of numerical values allowed for the defined item, or
-    for elements of 'Array' types. If the defined item has associated SU values,
-    the reported data values may fall outside these limits.
+    for all elements of 'Array' or 'List' types. If the defined item has
+    associated SU values, the reported data values may fall outside these limits.
 ;
     _name.category_id             enumeration
     _name.object_id               range

--- a/ddl.dic
+++ b/ddl.dic
@@ -1229,8 +1229,9 @@ save_enumeration.range
     _description.text
 ;
     The inclusive range of numerical values allowed for the defined item, or
-    for all elements of 'Array' or 'List' types. If the defined item has
-    associated SU values, the reported data values may fall outside these limits.
+    for all elements of 'Array' or 'List' types, or for all values of 'Table'
+    types. If the defined item has associated SU values, the reported data
+    values may fall outside these limits.
 ;
     _name.category_id             enumeration
     _name.object_id               range

--- a/ddl.dic
+++ b/ddl.dic
@@ -1228,9 +1228,9 @@ save_enumeration.range
     _definition.update            2023-01-09
     _description.text
 ;
-    The inclusive range of numerical values allowed for the defined item.
-    If the defined item has associated SU values, the reported data values
-    may fall outside these limits.
+    The inclusive range of numerical values allowed for the defined item, or
+    for elements of 'Array' types. If the defined item has associated SU values,
+    the reported data values may fall outside these limits.
 ;
     _name.category_id             enumeration
     _name.object_id               range


### PR DESCRIPTION
`_enumeration.range` can apply to `Array` types with no ambiguity, so I thought it was worth stating that it can apply to the contents of array types as well. Other compound types are not covered, as `Lists` can have heterogenous types, as can `Tables`.