### PR TITLE
Added Uri-ref and Iri-ref as content types

### DIFF
--- a/ddl.dic
+++ b/ddl.dic
@@ -2236,7 +2236,8 @@ save_type.contents
 ;
          Iri-ref
 ;
-         Internationalized Resource Identifier as defined in RFC 3987.
+         Internationalized Resource Identifier reference as defined
+         in RFC 3987.
 
          Ref: Duerst, M. and Suignard, M. (2005). Internationalized
          Resource Identifiers (IRIs). RFC 3987.

--- a/ddl.dic
+++ b/ddl.dic
@@ -11,7 +11,7 @@ data_DDL_DIC
     _dictionary.title             DDL_DIC
     _dictionary.class             Reference
     _dictionary.version           4.2.0
-    _dictionary.date              2026-02-25
+    _dictionary.date              2026-06-25
     _dictionary.uri
         https://raw.githubusercontent.com/COMCIFS/DDLm/main/ddl.dic
     _dictionary.ddl_conformance   4.2.0
@@ -1660,7 +1660,7 @@ save_import_details.file_id
     _type.purpose                 Identify
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Uri
+    _type.contents                Uri-ref
 
 save_
 
@@ -2209,14 +2209,32 @@ save_type.contents
 ;
          Uri
 ;
-         Uniform Resource Identifier reference as defined in RFC 3986 Section
-         4.1.
+         An absolute Uniform Resource Identifier as defined in RFC 3986.
 
          Ref: Berners-Lee, T., Fielding, R. and Masinter, L. (2005). STD 66:
          Uniform Resource Identifier (URI): Generic Syntax. RFC 3986.
-         https://www.rfc-editor.org/rfc/rfc3986
+         Section 4.3. Absolute URI.
+         https://www.rfc-editor.org/rfc/rfc3986#section-4.3
+;
+         Uri-ref
+;
+         Uniform Resource Identifier reference as defined in RFC 3986 Section
+         4.1. A URI reference may be either an absolute or a relative URI.
+
+         Ref: Berners-Lee, T., Fielding, R. and Masinter, L. (2005). STD 66:
+         Uniform Resource Identifier (URI): Generic Syntax. RFC 3986.
+         Section 4.1. URI Reference.
+         https://www.rfc-editor.org/rfc/rfc3986#section-4.1
 ;
          Iri
+;
+         Internationalized Resource Identifier as defined in RFC 3987.
+
+         Ref: Duerst, M. and Suignard, M. (2005). Internationalized
+         Resource Identifiers (IRIs). RFC 3987.
+         https://www.rfc-editor.org/rfc/rfc3987
+;
+         Iri-ref
 ;
          Internationalized Resource Identifier as defined in RFC 3987.
 
@@ -3219,7 +3237,7 @@ save_
        by explicitly specifying that it adheres to the formal grammar
        provided in SemVer version 2.0.0.
 ;
-         4.2.0                    2026-02-25
+         4.2.0                    2026-06-25
 ;
        Added the "unspecified" enumeration value for the _units.code attribute.
 
@@ -3263,4 +3281,9 @@ save_
 
        Added '_dictionary_author.name', '_dictionary_author.id_orcid' and
        '_dictionary_author.email' to the recommended attribute list.
+
+       Added 'Uri-ref' and 'Iri-ref' as machine-parsable content types, and
+       specified that the 'Uri' content type must be an *absolute* URI. In
+       consequence, changed the _type.contents of _import_details.file_id
+       to Uri-ref.
 ;


### PR DESCRIPTION
... and amended `_type.contents` of `_import_details.file_id` to `Uri-ref`.

This follows @jamesrhester 's comment in PR https://github.com/COMCIFS/DDLm/pull/30 that it would be preferable to differentiate between full URIs and URI references as separate types. I have preferred to introduce Uri-ref for the reference and revert Uri to the full URI form in order to match the nomenclature within the RFCs.

Note that I have used the term 'absolute URI' for the Uri type, but be aware that (by my reading of RFC 3986) this **excludes** the 'fragment' component, so that the URLs I quote for the explicit sections of RFC 3986 are, technically, not absolute URIs.  I haven't added section references to RFC 3987 (IRIs) because the terms 'IRI' and 'IRI reference' are not so clearly separated.

If @jamesrhester prefers to retain the current 'Uri' and add 'Uri-abs' instead, I'm happy to withdraw this PR. Or we could leave the current revision (merged PR https://github.com/COMCIFS/DDLm/pull/30) in place, as a URI reference always includes a full URI. It is possible that a misguided attempt to be too precise might have unintended (adverse) consequences).