### PR TITLE
Rename Uri to Uri-ref for _type.indices type

### DIFF
--- a/ddl.dic
+++ b/ddl.dic
@@ -2423,7 +2423,7 @@ save_type.indices
 ;
          ISO date format <yyyy>-<mm>-<dd>.
 ;
-         Uri
+         Uri-ref
 ;
          Uniform Resource Identifier reference as defined in RFC 3986 Section
          4.1.


### PR DESCRIPTION
For consistency with _type.contents types. Fixes #34.